### PR TITLE
some server implementation userinfo endpoint only use auth header for…

### DIFF
--- a/packages/switch:oidc/oidc_server.js
+++ b/packages/switch:oidc/oidc_server.js
@@ -81,7 +81,7 @@ var getUserInfo = function (accessToken) {
   var serverUserinfoEndpoint = config.serverUrl + config.userinfoEndpoint;
   var response;
   try {
-    response = HTTP.get(
+    response = HTTP.post(
       serverUserinfoEndpoint,
       {
         headers: {


### PR DESCRIPTION
… access_token, like keycloak