### PR TITLE
expose extra user data to services

### DIFF
--- a/packages/switch:accounts-oidc/README.md
+++ b/packages/switch:accounts-oidc/README.md
@@ -46,6 +46,7 @@ The following service configuration are available:
 * `authorizationEndpoint`: Endpoint of the OIDC authorization service, e.g. `/oidc/authorize`
 * `tokenEndpoint`: Endpoint of the OIDC token service, e.g. `/oidc/token`
 * `userinfoEndpoint`: Endpoint of the OIDC userinfo service, e.g. `/oidc/userinfo`
+* `idTokenWhitelistFields`: A list of fields from IDToken to be added to Meteor.user().services.oidc object
 
 ### Project Configuration
 
@@ -65,6 +66,7 @@ if (Meteor.isServer) {
           authorizationEndpoint: '/oidc/authorize',
           tokenEndpoint: '/oidc/token',
           userinfoEndpoint: '/oidc/userinfo',
+          idTokenWhitelistFields: []
         }
       }
     );

--- a/packages/switch:oidc/oidc_configure.js
+++ b/packages/switch:oidc/oidc_configure.js
@@ -11,6 +11,7 @@ Template.configureLoginServiceDialogForOidc.fields = function () {
     { property: 'serverUrl', label: 'OIDC Server URL'},
     { property: 'authorizationEndpoint', label: 'Authorization Endpoint'},
     { property: 'tokenEndpoint', label: 'Token Endpoint'},
-    { property: 'userinfoEndpoint', label: 'Userinfo Endpoint'}
+    { property: 'userinfoEndpoint', label: 'Userinfo Endpoint'},
+    { property: 'idTokenWhitelistFields', label: 'Id Token Fields'}
   ];
 };


### PR DESCRIPTION
Add functionality to include extra specific service data, this can be vendor specific.

For example, twitter auth client does this.

https://github.com/meteor/meteor/blob/fec8303c214e3dc2ea4940d6158a37a5433050fd/packages/twitter/twitter_server.js